### PR TITLE
fix bugs related to sorting the years

### DIFF
--- a/client/src/screens/browse/components/year-info/index.jsx
+++ b/client/src/screens/browse/components/year-info/index.jsx
@@ -31,14 +31,6 @@ const YearInfo = ({
         (c) => c.code.toLowerCase() === courseCode?.toLowerCase()
     );
     
-    const sortYear = (a, b) => {
-        if (a?.name > b?.name) return 1;
-        else if(a?.name < b?.name) return -1;
-        else return 1;
-    }
-
-    if(course?.length > 1) course.sort(sortYear);
-
     const handleAddYear = () => {
         setNewYearName("");
         setShowConfirm(true);

--- a/server/modules/course/course.controller.js
+++ b/server/modules/course/course.controller.js
@@ -64,6 +64,15 @@ export const getCourse = async (req, res, next) => {
     if (!course) {
         course = await createCourse(code);
     }
+
+    //function to sort the years in descending order for displaying in frontend
+    const sortYear = (a, b) => {
+        if (a?.name > b?.name) return 1;
+        else if(a?.name < b?.name) return -1;
+        else return 1;
+    }
+
+    if(course?.children.length > 1) course.children.sort(sortYear);
     return res.json({ found: true, ...course["_doc"] });
 };
 


### PR DESCRIPTION
sorted the years in backend and then sent the data to frontend instead of directly sorting in the frontend which fixed two bugs which were created due to sorting in frontend. The bugs were
1. clicking course card in dashboard opens the wrong year
2. sometimes while refreshing the thumbnails a different year gets opened in collapsible