### PR TITLE
Prajit

### DIFF
--- a/admin/.gitignore
+++ b/admin/.gitignore
@@ -12,7 +12,7 @@ dist
 dist-ssr
 *.local
 package-lock.json
-apis/server.js
+src/apis/server.js
 
 # Editor directories and files
 .vscode/*

--- a/admin/src/apis/server.js
+++ b/admin/src/apis/server.js
@@ -1,1 +1,0 @@
-export const API_BASE_URL = "http://localhost:8080/";

--- a/server/services/UploadFile.js
+++ b/server/services/UploadFile.js
@@ -46,7 +46,7 @@ async function CreateFolder(contributionId) {
         const { data } = await axios.post(url, _data, config);
         return data.id;
     } catch (error) {
-        console.log(error);
+        // console.log(error);
         if (error.response.status === 409) {
             const folderId = await GetFolderId(contributionId);
             return folderId;
@@ -69,13 +69,13 @@ async function createUploadSession(folderId, fileName) {
         const { data } = await axios.post(url, {}, config);
         return { url: data?.uploadUrl, access_token };
     } catch (error) {
+        console.log(error);
         return false;
     }
 }
 
 async function UploadFile(contributionId, filePath, fileName) {
-    const folderId = await CreateFolder(contributionId);
-    if (!folderId) return false; //error here
+    const folderId = parent_item_id;
     const { url, access_token } = await createUploadSession(folderId, fileName);
     if (!url) {
         console.log("Error uploading!");


### PR DESCRIPTION
Fix the multiple file upload issue by attempting the following:

previously each file was stored in a folder created during the contribution with folder name being the contribution id. This was not only extremely wasteful but further there was some issue with using microsoft conflict behavior to check the existence of a folder which caused only 1 file to be uploaded out of many. Therefore files will now be stored in the parent folder itself without any subfolders.