### PR TITLE
Block empty contribution submit; show error toast

### DIFF
--- a/client/src/screens/contributions/index.jsx
+++ b/client/src/screens/contributions/index.jsx
@@ -38,6 +38,12 @@ const Contributions = () => {
     async function handleSubmit() {
         if (isUploading) return;
 
+        const files = pond.current ? pond.current.getFiles() : [];
+        if (!submitEnabled || !files.length) {
+            toast.error("Please upload a valid file");
+            return;
+        }
+
         const collection = document.getElementsByClassName("contri");
         const contributionSection = collection[0];
 


### PR DESCRIPTION
## Summary

Clicking Submit with no files selected still created a contribution and showed a success toast (the button only looked disabled via CSS).

- Guard `handleSubmit` on FilePond file count / `submitEnabled`
- `toast.error("Please upload a valid file")` instead of the success path

## Test plan

- [x] Open contribute UI with no files → Submit → error toast, no success
- [x] Select file(s) → Submit → upload still works

Fixes #188